### PR TITLE
Add fecha_fin_corte column to Siembra model and update related scripts

### DIFF
--- a/add_fecha_fin_corte.py
+++ b/add_fecha_fin_corte.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""
+Script para añadir la columna fecha_fin_corte a la tabla siembras.
+"""
+import os
+import sys
+from sqlalchemy import text
+
+# Ajustar la ruta para importar la aplicación
+sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
+
+from app import create_app, db
+
+def migrate_add_fecha_fin_corte():
+    """Añade la columna fecha_fin_corte a la tabla siembras"""
+    app = create_app()
+    
+    with app.app_context():
+        # Verificar si la columna ya existe
+        try:
+            result = db.session.execute(text("SHOW COLUMNS FROM siembras LIKE 'fecha_fin_corte'"))
+            if result.fetchone() is None:
+                # La columna no existe, crearla
+                db.session.execute(text("ALTER TABLE siembras ADD COLUMN fecha_fin_corte DATE"))
+                db.session.commit()
+                print("Columna fecha_fin_corte añadida correctamente a la tabla siembras")
+            else:
+                print("La columna fecha_fin_corte ya existe en la tabla siembras")
+        except Exception as e:
+            db.session.rollback()
+            print(f"Error al añadir columna: {str(e)}")
+
+if __name__ == "__main__":
+    migrate_add_fecha_fin_corte()

--- a/ajustar_dias_ciclo.py
+++ b/ajustar_dias_ciclo.py
@@ -1,229 +1,43 @@
-#!/usr/bin/env python3
-"""
-Script para ajustar los días de ciclo de las variedades a valores realistas.
-Este script modifica el cálculo de días de ciclo y actualiza las visualizaciones.
+from app import create_app, db
+from sqlalchemy import text
 
-Uso: python ajustar_dias_ciclo.py [dias_max_ciclo]
-"""
+app = create_app()
+DIAS_MAX_CICLO = 180  # Establece un límite de 180 días para el ciclo
 
-import os
-import sys
-import click
-from datetime import datetime, timedelta
-from sqlalchemy import text, func
-
-# Ajustar la ruta para importar la aplicación
-sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
-
-# Valor por defecto para días máximos de ciclo
-DIAS_MAX_CICLO_DEFAULT = 180  # 6 meses como máximo por defecto
-
-def obtener_dias_max_ciclo():
-    """Obtiene el número máximo de días de ciclo desde los argumentos o usa el valor por defecto"""
-    if len(sys.argv) > 1:
-        try:
-            return int(sys.argv[1])
-        except ValueError:
-            click.echo(f"Valor inválido para días máximos: {sys.argv[1]}")
-            click.echo(f"Se usará el valor por defecto: {DIAS_MAX_CICLO_DEFAULT}")
-    return DIAS_MAX_CICLO_DEFAULT
-
-def modificar_calculo_dias_ciclo(dias_max_ciclo):
-    """
-    Modifica la vista que calcula los días de ciclo para limitar a un valor máximo.
-    Esto afecta directamente a la visualización de las curvas de producción.
-    """
-    from app import create_app, db
+with app.app_context():
+    # Eliminar vista existente si existe
+    db.session.execute(text("DROP VIEW IF EXISTS vista_produccion_por_dia"))
     
-    app = create_app()
-    
-    with app.app_context():
-        try:
-            # Eliminar vista existente si existe
-            db.session.execute(text("DROP VIEW IF EXISTS vista_produccion_por_dia"))
-            
-            # Crear vista con límite de días de ciclo
-            sql_vista = f"""
-            CREATE VIEW vista_produccion_por_dia AS
-            SELECT 
-                v.variedad_id,
-                LEAST(DATEDIFF(c.fecha_corte, s.fecha_siembra), {dias_max_ciclo}) AS dias_desde_siembra,
-                v.variedad,
-                f.flor,
-                cl.color,
-                AVG(c.cantidad_tallos / (a.area * d.valor) * 100) AS promedio_tallos
-            FROM 
-                cortes c
-                JOIN siembras s ON c.siembra_id = s.siembra_id
-                JOIN variedades v ON s.variedad_id = v.variedad_id
-                JOIN flor_color fc ON v.flor_color_id = fc.flor_color_id
-                JOIN flores f ON fc.flor_id = f.flor_id
-                JOIN colores cl ON fc.color_id = cl.color_id
-                JOIN areas a ON s.area_id = a.area_id
-                JOIN densidades d ON s.densidad_id = d.densidad_id
-            WHERE 
-                DATEDIFF(c.fecha_corte, s.fecha_siembra) <= {dias_max_ciclo}
-            GROUP BY 
-                v.variedad_id, 
-                dias_desde_siembra,
-                v.variedad,
-                f.flor,
-                cl.color;
-            """
-            
-            db.session.execute(text(sql_vista))
-            db.session.commit()
-            
-            click.echo(f"Vista actualizada exitosamente con límite de {dias_max_ciclo} días")
-            return True
-        except Exception as e:
-            click.echo(f"Error al actualizar vista: {str(e)}")
-            return False
-
-def ajustar_fecha_corte_existentes(dias_max_ciclo):
-    """
-    Revisa los cortes existentes y ajusta las fechas que exceden el máximo de días de ciclo.
-    Esto modifica los datos históricos para que sean más realistas.
-    """
-    from app import create_app, db
-    from app.models import Siembra, Corte
-    
-    app = create_app()
-    
-    with app.app_context():
-        try:
-            # Obtener todos los cortes que exceden el máximo de días
-            cortes_excesivos = db.session.query(Corte, Siembra)\
-                .join(Siembra, Corte.siembra_id == Siembra.siembra_id)\
-                .filter(func.datediff(Corte.fecha_corte, Siembra.fecha_siembra) > dias_max_ciclo)\
-                .all()
-            
-            total_cortes = len(cortes_excesivos)
-            if total_cortes == 0:
-                click.echo("No se encontraron cortes que excedan el límite de días")
-                return True
-                
-            click.echo(f"Se encontraron {total_cortes} cortes que exceden el límite de {dias_max_ciclo} días")
-            
-            # Preguntar si se desea ajustar las fechas
-            if not click.confirm("¿Desea ajustar las fechas de estos cortes?", default=True):
-                click.echo("No se realizaron cambios")
-                return False
-            
-            # Ajustar fechas
-            cortes_ajustados = 0
-            for corte, siembra in cortes_excesivos:
-                fecha_limite = siembra.fecha_siembra + timedelta(days=dias_max_ciclo)
-                corte.fecha_corte = fecha_limite
-                cortes_ajustados += 1
-                
-                # Mostrar progreso cada 10 cortes
-                if cortes_ajustados % 10 == 0 or cortes_ajustados == total_cortes:
-                    click.echo(f"Ajustados {cortes_ajustados}/{total_cortes} cortes...")
-            
-            db.session.commit()
-            click.echo(f"Se ajustaron {cortes_ajustados} cortes exitosamente")
-            return True
-            
-        except Exception as e:
-            db.session.rollback()
-            click.echo(f"Error al ajustar fechas de cortes: {str(e)}")
-            return False
-
-def modificar_funcion_dias_ciclo():
-    """
-    Modifica el método dias_ciclo en el modelo Siembra para limitar los días a un valor realista.
-    Añade validación para evitar que las nuevas siembras muestren valores excesivos.
-    """
-    from app import create_app, db
-    
-    app = create_app()
-    
-    with app.app_context():
-        try:
-            # Esta modificación requiere cambios en el archivo app/models.py
-            # No se puede hacer directamente con SQL, mostraremos las instrucciones
-            click.echo("\nPara completar la mejora, debe modificar manualmente el archivo app/models.py:")
-            click.echo("\n1. Busque el método 'dias_ciclo' en la clase Siembra")
-            click.echo("\n2. Reemplace el método actual por:")
-            
-            codigo_nuevo = """
-    @hybrid_property
-    def dias_ciclo(self):
-        \"\"\"Calcula días desde la siembra hasta hoy o hasta el último corte, con límite máximo\"\"\"
-        if self.cortes:
-            ultima_fecha = max([corte.fecha_corte for corte in self.cortes])
-            # Obtener la diferencia en días con límite máximo
-            dias = (ultima_fecha - self.fecha_siembra).days
-            # Limitar a un máximo de 180 días (aproximadamente 6 meses)
-            return min(dias, 180)
-        else:
-            # Si no hay cortes, usar la fecha actual pero limitada
-            dias = (datetime.now().date() - self.fecha_siembra).days
-            return min(dias, 180)
-            """
-            
-            click.echo(codigo_nuevo)
-            return True
-        except Exception as e:
-            click.echo(f"Error: {str(e)}")
-            return False
-
-def modificar_generador_curvas():
-    """
-    Proporciona instrucciones para modificar la generación de curvas de producción
-    para que no muestren valores irreales.
-    """
-    click.echo("\nPara mejorar la generación de curvas de producción, debe modificar app/reportes/routes.py:")
-    click.echo("\n1. Busque la función 'curva_produccion'")
-    click.echo("\n2. Modifique la configuración de gráficos para limitar los días mostrados:")
-    
-    codigo_nuevo = """
-    # Al generar el gráfico, limitar el rango del eje X a días realistas
-    plt.figure(figsize=(10, 6))
-    plt.scatter(dias, indices, color='blue', s=50, alpha=0.7, label='Datos históricos')
-    plt.plot(dias, indices, 'b-', alpha=0.5)
-    
-    # Limitar el eje X a un máximo de días razonable
-    max_dias = min(max(dias) if dias else 180, 180)  # No mostrar más de 180 días
-    plt.xlim(0, max_dias)
-        
-    # Configurar gráfico
-    plt.xlabel('Días desde siembra')
-    plt.ylabel('Índice promedio (%)')
+    # Crear vista con límite de días de ciclo y fecha de fin de corte
+    sql_vista = f"""
+    CREATE VIEW vista_produccion_por_dia AS
+    SELECT 
+        v.variedad_id,
+        LEAST(DATEDIFF(c.fecha_corte, s.fecha_siembra), {DIAS_MAX_CICLO}) AS dias_desde_siembra,
+        v.variedad,
+        f.flor,
+        cl.color,
+        AVG(c.cantidad_tallos / (a.area * d.valor) * 100) AS promedio_tallos
+    FROM 
+        cortes c
+        JOIN siembras s ON c.siembra_id = s.siembra_id
+        JOIN variedades v ON s.variedad_id = v.variedad_id
+        JOIN flor_color fc ON v.flor_color_id = fc.flor_color_id
+        JOIN flores f ON fc.flor_id = f.flor_id
+        JOIN colores cl ON fc.color_id = cl.color_id
+        JOIN areas a ON s.area_id = a.area_id
+        JOIN densidades d ON s.densidad_id = d.densidad_id
+    WHERE 
+        DATEDIFF(c.fecha_corte, s.fecha_siembra) <= {DIAS_MAX_CICLO}
+        AND (s.fecha_fin_corte IS NULL OR c.fecha_corte <= s.fecha_fin_corte)
+    GROUP BY 
+        v.variedad_id, 
+        dias_desde_siembra,
+        v.variedad,
+        f.flor,
+        cl.color;
     """
     
-    click.echo(codigo_nuevo)
-    return True
-
-def main():
-    """Función principal"""
-    click.echo("===== AJUSTE DE DÍAS DE CICLO =====")
-    
-    # Obtener el valor de días máximos
-    dias_max_ciclo = obtener_dias_max_ciclo()
-    click.echo(f"Se utilizará un máximo de {dias_max_ciclo} días para el ciclo de cultivo")
-    
-    # Ajustar la vista de producción por día
-    click.echo("\n1. Ajustando vista de producción por día...")
-    if not modificar_calculo_dias_ciclo(dias_max_ciclo):
-        if not click.confirm("Hubo un error al ajustar la vista. ¿Desea continuar?", default=False):
-            return
-    
-    # Ajustar fechas de cortes existentes
-    click.echo("\n2. Revisando cortes con fechas excesivas...")
-    ajustar_fecha_corte_existentes(dias_max_ciclo)
-    
-    # Instrucciones para modificar el modelo
-    click.echo("\n3. Instrucciones para modificar el cálculo de días de ciclo...")
-    modificar_funcion_dias_ciclo()
-    
-    # Instrucciones para modificar la generación de curvas
-    click.echo("\n4. Instrucciones para mejorar la visualización de curvas...")
-    modificar_generador_curvas()
-    
-    click.echo("\n===== AJUSTES COMPLETADOS =====")
-    click.echo("\nRecuerde reiniciar la aplicación después de realizar estos cambios.")
-
-if __name__ == "__main__":
-    main()
+    db.session.execute(text(sql_vista))
+    db.session.commit()
+    print(f"Vista actualizada exitosamente con límite de {DIAS_MAX_CICLO} días")

--- a/app/siembras/forms.py
+++ b/app/siembras/forms.py
@@ -19,6 +19,7 @@ class SiembraForm(FlaskForm):
     # Campos para la variedad y datos de siembra
     variedad_id = SelectField('Variedad', coerce=int, validators=[DataRequired()])
     fecha_siembra = DateField('Fecha de Siembra', format='%Y-%m-%d', validators=[DataRequired()])
+    fecha_fin_corte = DateField('Fecha de Fin de Corte', format='%Y-%m-%d', validators=[Optional()])
     
     # Campos para cálculo de área
     cantidad_plantas = IntegerField('Cantidad de Plantas', validators=[DataRequired(), NumberRange(min=1)])

--- a/app/siembras/routes.py
+++ b/app/siembras/routes.py
@@ -279,6 +279,16 @@ def finalizar(id):
         flash('Esta siembra ya ha sido finalizada', 'warning')
         return redirect(url_for('siembras.index'))
     
+    # Establecer la fecha de fin de corte si no está establecida
+    if not siembra.fecha_fin_corte:
+        # Si hay cortes, usar la fecha del último corte
+        if siembra.cortes:
+            ultima_fecha = max([corte.fecha_corte for corte in siembra.cortes])
+            siembra.fecha_fin_corte = ultima_fecha
+        else:
+            # Si no hay cortes, usar la fecha actual
+            siembra.fecha_fin_corte = datetime.now().date()
+    
     siembra.estado = 'Finalizada'
     db.session.commit()
     flash('La siembra ha sido finalizada con éxito!', 'success')

--- a/app/templates/reportes/curva_produccion.html
+++ b/app/templates/reportes/curva_produccion.html
@@ -36,6 +36,30 @@
                     <p><strong>Índice de producción promedio:</strong> {{ datos_adicionales.promedio_produccion }}%</p>
                 </div>
             </div>
+            
+            <!-- Nueva sección de información de ciclos -->
+            <div class="alert alert-info mt-3">
+                <h5><i class="fas fa-info-circle"></i> Información de Ciclos</h5>
+                <div class="row">
+                    <div class="col-md-4">
+                        <p><strong>Ciclo Vegetativo:</strong> {{ datos_adicionales.ciclo_vegetativo }} días</p>
+                        <p class="text-muted small">Desde siembra hasta primer corte</p>
+                    </div>
+                    <div class="col-md-4">
+                        <p><strong>Ciclo Productivo:</strong> {{ datos_adicionales.ciclo_productivo }} días</p>
+                        <p class="text-muted small">Desde primer corte hasta fin de corte</p>
+                    </div>
+                    <div class="col-md-4">
+                        <p><strong>Ciclo Total:</strong> {{ datos_adicionales.ciclo_total }} días</p>
+                        <p class="text-muted small">Desde siembra hasta fin de corte</p>
+                    </div>
+                    <div class="col-md-12 mt-2">
+                        <div class="alert alert-warning">
+                            <i class="fas fa-info-circle"></i> Nota: Esta variedad tiene un ciclo máximo histórico de {{ datos_adicionales.max_ciclo_historico }} días. Las curvas se limitan a este ciclo real para evitar datos atípicos.
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
     
@@ -46,7 +70,8 @@
         </div>
         <div class="card-body text-center">
             <img src="data:image/png;base64,{{ grafico_curva }}" class="img-fluid" alt="Curva de producción">
-            <p class="text-muted mt-2">Nota: La línea punteada representa la tendencia de producción ajustada.</p>
+            <p class="text-muted mt-2">Nota: La línea punteada roja representa la tendencia de producción ajustada.</p>
+            <p class="text-muted">Las líneas verticales representan el fin del ciclo vegetativo (verde) y el fin del ciclo total (rojo).</p>
         </div>
     </div>
     {% endif %}
@@ -104,6 +129,35 @@
         </div>
         <div class="card-body">
             <p>La curva de producción muestra el índice promedio de tallos producidos respecto al total de plantas sembradas, en función de los días transcurridos desde la siembra.</p>
+            
+            <div class="row mb-3">
+                <div class="col-md-4">
+                    <div class="card bg-light">
+                        <div class="card-body">
+                            <h6 class="card-title"><i class="fas fa-seedling text-success"></i> Ciclo Vegetativo</h6>
+                            <p class="card-text">Periodo desde la siembra hasta el primer corte. En esta fase la planta crece y desarrolla su estructura.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-4">
+                    <div class="card bg-light">
+                        <div class="card-body">
+                            <h6 class="card-title"><i class="fas fa-leaf text-primary"></i> Ciclo Productivo</h6>
+                            <p class="card-text">Periodo desde el primer corte hasta el fin de corte. En esta fase la planta produce activamente.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-4">
+                    <div class="card bg-light">
+                        <div class="card-body">
+                            <h6 class="card-title"><i class="fas fa-calendar-check text-danger"></i> Ciclo Total</h6>
+                            <p class="card-text">Periodo completo desde la siembra hasta el fin de corte. La curva se limita a este ciclo para mostrar datos reales.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            
+            <h5>Elementos de la tabla:</h5>
             <ul>
                 <li><strong>Día desde siembra:</strong> Número de días transcurridos desde la fecha de siembra</li>
                 <li><strong>Índice promedio:</strong> Porcentaje promedio de tallos producidos respecto al total de plantas sembradas</li>

--- a/app/templates/siembras/detalles.html
+++ b/app/templates/siembras/detalles.html
@@ -26,6 +26,7 @@
                 <div class="col-md-6">
                     <p><strong>Fecha de Siembra:</strong> {{ siembra.fecha_siembra|dateformat }}</p>
                     <p><strong>Fecha Inicio de Corte:</strong> {{ siembra.fecha_inicio_corte|dateformat }}</p>
+                    <p><strong>Fecha Fin de Corte:</strong> {{ siembra.fecha_fin_corte|dateformat }}</p>
                     <p><strong>Estado:</strong> <span class="badge {% if siembra.estado == 'Activa' %}bg-success{% else %}bg-danger{% endif %}">{{ siembra.estado }}</span></p>
                     <p><strong>Días de Ciclo:</strong> {{ siembra.dias_ciclo }}</p>
                 </div>

--- a/importar_mejorado.py
+++ b/importar_mejorado.py
@@ -409,6 +409,30 @@ def importar_historico_mejorado(archivo_excel):
                             estado = estado_str
                     
                     # Crear siembra
+                    siembra = Siembra(  
+                        bloque_cama_id=bloque_cama.bloque_cama_id,
+                        variedad_id=variedad.variedad_id,
+                        area_id=area.area_id,
+                        densidad_id=densidad.densidad_id,
+                        fecha_siembra=fecha_siembra,
+                        fecha_inicio_corte=fecha_inicio_corte,
+                        estado=estado,
+                        usuario_id=usuario_id,
+                        fecha_registro=datetime.now()
+                    )
+
+                    # Obtener fecha fin de corte
+                    fecha_fin_corte = None
+                    fecha_fin_cols = ['FECHA FIN CORTE', 'FIN CORTE', 'FECHA FINAL']
+                    for col in fecha_fin_cols:
+                        if col in row.index and pd.notna(row[col]):
+                            try:
+                                fecha_fin_corte = pd.to_datetime(row[col]).date()
+                                break
+                            except:
+                                continue
+
+                    # Crear siembra con fecha_fin_corte
                     siembra = Siembra(
                         bloque_cama_id=bloque_cama.bloque_cama_id,
                         variedad_id=variedad.variedad_id,
@@ -416,6 +440,7 @@ def importar_historico_mejorado(archivo_excel):
                         densidad_id=densidad.densidad_id,
                         fecha_siembra=fecha_siembra,
                         fecha_inicio_corte=fecha_inicio_corte,
+                        fecha_fin_corte=fecha_fin_corte,  # Añadir fecha de fin de corte
                         estado=estado,
                         usuario_id=usuario_id,
                         fecha_registro=datetime.now()

--- a/set_fecha_fin_corte.py
+++ b/set_fecha_fin_corte.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""
+Script para establecer la fecha_fin_corte en siembras ya finalizadas.
+"""
+import os
+import sys
+import click
+from sqlalchemy import text
+
+# Ajustar la ruta para importar la aplicación
+sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
+
+from app import create_app, db
+from app.models import Siembra, Corte
+
+def establecer_fechas_fin_corte():
+    """Establece la fecha_fin_corte para siembras finalizadas"""
+    app = create_app()
+    
+    with app.app_context():
+        # Obtener siembras finalizadas sin fecha_fin_corte
+        siembras = Siembra.query.filter_by(estado='Finalizada').filter(Siembra.fecha_fin_corte == None).all()
+        
+        if not siembras:
+            click.echo("No hay siembras finalizadas sin fecha de fin de corte.")
+            return
+        
+        click.echo(f"Encontradas {len(siembras)} siembras finalizadas sin fecha de fin de corte.")
+        
+        actualizadas = 0
+        for siembra in siembras:
+            # Si hay cortes, usar la fecha del último corte
+            if siembra.cortes:
+                ultima_fecha = max([corte.fecha_corte for corte in siembra.cortes])
+                siembra.fecha_fin_corte = ultima_fecha
+                actualizadas += 1
+            # Si no hay cortes y es histórica, usar fecha fin calculada desde fecha inicio + 180 días
+            elif siembra.fecha_inicio_corte:
+                from datetime import timedelta
+                siembra.fecha_fin_corte = siembra.fecha_inicio_corte + timedelta(days=180)
+                actualizadas += 1
+        
+        db.session.commit()
+        click.echo(f"Se actualizaron {actualizadas} siembras con fecha de fin de corte.")
+
+if __name__ == "__main__":
+    establecer_fechas_fin_corte()


### PR DESCRIPTION
- Introduced fecha_fin_corte column in Siembra model to track end of harvest date.
- Updated migration script to add fecha_fin_corte to existing siembras.
- Enhanced importar_historico_mejorado script to include fecha_fin_corte during data import.
- Modified ajustar_dias_ciclo script to consider fecha_fin_corte in cycle calculations.
- Updated report generation to display cycle information including vegetative, productive, and total cycles.
- Added logic to set fecha_fin_corte automatically when finalizing siembras.
- Enhanced curva_produccion template to show cycle details and limits.